### PR TITLE
Add fixed login and calendar view

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
             <input type="text" id="eventDesc" required>
             <button type="submit">Add Event</button>
         </form>
-        <ul id="eventList"></ul>
+        <div id="calendarGrid" class="calendar-grid"></div>
         <button id="logoutBtn">Logout</button>
     </section>
 

--- a/login.html
+++ b/login.html
@@ -1,8 +1,20 @@
- <section id="login" class="hidden">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <section id="login">
         <h2>Login</h2>
         <form id="loginForm">
-            <label for="password">password:</label>
-            <input type="text" id="password" required>
+            <label for="password">Password:</label>
+            <input type="password" id="password" required>
             <button type="submit">Login</button>
         </form>
     </section>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,75 +1,110 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const loginSection = document.getElementById('login');
-    const calendarSection = document.getElementById('calendar');
     const loginForm = document.getElementById('loginForm');
+    const calendarSection = document.getElementById('calendar');
     const eventForm = document.getElementById('eventForm');
-    const eventList = document.getElementById('eventList');
+    const calendarGrid = document.getElementById('calendarGrid');
     const logoutBtn = document.getElementById('logoutBtn');
 
-    function getUser() {
-        return localStorage.getItem('loggedInUser');
+    function isLoggedIn() {
+        return localStorage.getItem('loggedIn') === 'yes';
     }
 
     function eventsKey() {
-        return `events_${getUser()}`;
+        return 'events_2004';
     }
 
-    function show(section) {
-        section.classList.remove('hidden');
-    }
-
-    function hide(section) {
-        section.classList.add('hidden');
-    }
-
-    function loadEvents() {
+    function buildCalendar() {
+        if (!calendarGrid) return;
+        const now = new Date();
+        const year = now.getFullYear();
+        const month = now.getMonth();
+        const firstDay = new Date(year, month, 1).getDay();
+        const daysInMonth = new Date(year, month + 1, 0).getDate();
         const events = JSON.parse(localStorage.getItem(eventsKey())) || [];
-        eventList.innerHTML = '';
-        events.forEach((ev, index) => {
-            const li = document.createElement('li');
-            li.textContent = `${ev.date}: ${ev.desc}`;
-            eventList.appendChild(li);
+        const map = {};
+        events.forEach(ev => {
+            if (!map[ev.date]) map[ev.date] = [];
+            map[ev.date].push(ev.desc);
+        });
+
+        calendarGrid.innerHTML = '';
+        const weekDays = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+        weekDays.forEach(d => {
+            const head = document.createElement('div');
+            head.className = 'calendar-cell header';
+            head.textContent = d;
+            calendarGrid.appendChild(head);
+        });
+
+        for (let i = 0; i < firstDay; i++) {
+            const empty = document.createElement('div');
+            empty.className = 'calendar-cell';
+            calendarGrid.appendChild(empty);
+        }
+
+        for (let day = 1; day <= daysInMonth; day++) {
+            const cell = document.createElement('div');
+            cell.className = 'calendar-cell';
+            const dateDiv = document.createElement('div');
+            dateDiv.className = 'date';
+            dateDiv.textContent = day;
+            cell.appendChild(dateDiv);
+
+            const mm = String(month + 1).padStart(2, '0');
+            const dd = String(day).padStart(2, '0');
+            const dateKey = `${year}-${mm}-${dd}`;
+            if (map[dateKey]) {
+                map[dateKey].forEach(desc => {
+                    const p = document.createElement('div');
+                    p.textContent = desc;
+                    cell.appendChild(p);
+                });
+            }
+            calendarGrid.appendChild(cell);
+        }
+    }
+
+    if (loginForm) {
+        loginForm.addEventListener('submit', e => {
+            e.preventDefault();
+            const pwd = document.getElementById('password').value.trim();
+            if (pwd === '2004') {
+                localStorage.setItem('loggedIn', 'yes');
+                window.location.href = 'index.html';
+            } else {
+                alert('Incorrect password');
+            }
         });
     }
 
-    function checkLogin() {
-        if (getUser()) {
-            hide(loginSection);
-            show(calendarSection);
-            loadEvents();
-        } else {
-            show(loginSection);
-            hide(calendarSection);
-        }
+    if (logoutBtn) {
+        logoutBtn.addEventListener('click', () => {
+            localStorage.removeItem('loggedIn');
+            window.location.href = 'login.html';
+        });
     }
 
-    loginForm.addEventListener('submit', (e) => {
-        e.preventDefault();
-        const password = document.getElementById('password').value.trim();
-        if (password) {
-            localStorage.setItem('loggedInUser', password);
-            loginForm.reset();
-            checkLogin();
+    if (eventForm) {
+        eventForm.addEventListener('submit', e => {
+            e.preventDefault();
+            const date = document.getElementById('eventDate').value;
+            const desc = document.getElementById('eventDesc').value.trim();
+            if (date && desc) {
+                const events = JSON.parse(localStorage.getItem(eventsKey())) || [];
+                events.push({ date, desc });
+                localStorage.setItem(eventsKey(), JSON.stringify(events));
+                eventForm.reset();
+                buildCalendar();
+            }
+        });
+    }
+
+    if (calendarSection) {
+        if (!isLoggedIn()) {
+            window.location.href = 'login.html';
+            return;
         }
-    });
-
-    logoutBtn.addEventListener('click', () => {
-        localStorage.removeItem('loggedInUser');
-        checkLogin();
-    });
-
-    eventForm.addEventListener('submit', (e) => {
-        e.preventDefault();
-        const date = document.getElementById('eventDate').value;
-        const desc = document.getElementById('eventDesc').value.trim();
-        if (date && desc) {
-            const events = JSON.parse(localStorage.getItem(eventsKey())) || [];
-            events.push({ date, desc });
-            localStorage.setItem(eventsKey(), JSON.stringify(events));
-            eventForm.reset();
-            loadEvents();
-        }
-    });
-
-    checkLogin();
+        calendarSection.classList.remove('hidden');
+        buildCalendar();
+    }
 });

--- a/style.css
+++ b/style.css
@@ -40,3 +40,25 @@ footer {
 .hidden {
     display: none;
 }
+
+.calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 4px;
+}
+
+.calendar-cell {
+    border: 1px solid #ccc;
+    padding: 4px;
+    min-height: 60px;
+}
+
+.calendar-cell.header {
+    background: #eaeaea;
+    text-align: center;
+    font-weight: bold;
+}
+
+.calendar-cell .date {
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- enforce password `2004` and redirect to index after login
- redirect unauthenticated users to the login page
- replace event list with a small calendar grid
- style the grid to look like a calendar

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_685878987cf0832baae171956f177cde